### PR TITLE
Standardise actions filenames and go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,27 +1,22 @@
-name: ci-only
+name: build
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - '*'
 
 jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.13.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.13
-
       - uses: actions/checkout@master
         with:
           fetch-depth: 1
-
       - name: Make all
         run: make all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,6 @@ jobs:
   publish:
     strategy:
       matrix:
-        go-version: [1.13.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION

## Description
This changes the name of "ci-only" action to build as per comments in
https://github.com/openfaas/faas/issues/1585. Also pins go version
based on the same

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see action on this PR 

## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

