### PR TITLE
Updated to new location for Helm stable repository

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -278,7 +278,7 @@ func process(plan types.Plan, prefs InstallPreferences, additionalPaths []string
 		return nsErr
 	}
 
-	if err := helmRepoAdd("stable", "https://kubernetes-charts.storage.googleapis.com"); err != nil {
+	if err := helmRepoAdd("stable", "https://charts.helm.sh/stable"); err != nil {
 		log.Println(err.Error())
 		return err
 	}


### PR DESCRIPTION
## Description
https://kubernetes-charts.storage.googleapis.com is end of line as of November 13, 2020. New location for stable repository is https://charts.helm.sh/stable. Announcement from Helm available at https://helm.sh/blog/new-location-stable-incubator-charts/

## How Has This Been Tested?
`~$ helm version
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/kubeconfig-k3s-alpine
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/kubeconfig-k3s-alpine
WARNING: "kubernetes-charts.storage.googleapis.com" is deprecated for "stable" and will be deleted Nov. 13, 2020.
WARNING: You should switch to "https://charts.helm.sh/stable" via:
WARNING: helm repo add "stable" "https://charts.helm.sh/stable" --force-update
version.BuildInfo{Version:"v3.4.1", GitCommit:"c4e74854886b2efe3321e185578e6db9be0a6e29", GitTreeState:"clean", GoVersion:"go1.14.11"}`

`~$ helm repo add "stable" "https://charts.helm.sh/stable" --force-update
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/kubeconfig-k3s-alpine
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/kubeconfig-k3s-alpine
WARNING: "kubernetes-charts.storage.googleapis.com" is deprecated for "stable" and will be deleted Nov. 13, 2020.
WARNING: You should switch to "https://charts.helm.sh/stable" via:
WARNING: helm repo add "stable" "https://charts.helm.sh/stable" --force-update
"stable" has been added to your repositories`

`~$ helm repo update
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/kubeconfig-k3s-alpine
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/kubeconfig-k3s-alpine
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "ingress-nginx" chart repository
...Successfully got an update from the "portainer" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "openfaas" chart repository
...Successfully got an update from the "stable" chart repository`

## Checklist:

I have:

- [X] checked my changes follow the style of the existing code / OpenFaaS repos
- [X] updated the documentation and/or roadmap in README.md
- [X] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests

