### PR TITLE
Convert to using GHCR images

### DIFF
--- a/example.init.yaml
+++ b/example.init.yaml
@@ -331,5 +331,5 @@ enable_ingress_operator: false
 
 ## Version of OpenFaaS Cloud from https://github.com/openfaas/openfaas-cloud/releases/
 ### Usage: release tag, a SHA or branch name
-openfaas_cloud_version: 0.14.2
+openfaas_cloud_version: 0.14.4
 

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -80,15 +80,9 @@ if [ "$ENABLE_AWS_ECR" = "true" ] ; then
     faas-cli deploy -f ./aws.yml
 fi
 
-cd ./dashboard
-faas-cli template pull
-faas-cli deploy
+TAG=0.14.4 faas-cli deploy -f ./dashboard/stack.yml
 
 sleep 2
-
-# This `ServiceAccount` needs to be patched in place so that the function can perform create / get and update on the SealedSecret CRD:
-#kubectl patch -n openfaas-fn deploy import-secrets -p '{"spec":{"template":{"spec":{"serviceAccountName":"sealedsecrets-importer-rw"}}}}'
-# This is now applied through an annotation in stack.yml
 
 # Close the kubectl port-forward
 kill %1

--- a/templates/aws.yml
+++ b/templates/aws.yml
@@ -8,7 +8,7 @@ functions:
   register-image:
     lang: go
     handler: ./register-image
-    image: functions/register-image:0.2.1
+    image: ghcr.io/${REPO:-openfaas}/ofc-register-image:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system

--- a/templates/edge-auth-dep.yml
+++ b/templates/edge-auth-dep.yml
@@ -32,7 +32,7 @@ spec:
             secretName: of-customers
       containers:
       - name: edge-auth
-        image: openfaas/edge-auth:0.7.1
+        image: ghcr.io/openfaas/ofc-edge-auth:0.14.4
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/templates/gitlab.yml
+++ b/templates/gitlab.yml
@@ -6,7 +6,7 @@ functions:
   system-gitlab-event:
     lang: go
     handler: ./gitlab-event
-    image: functions/gitlab-event:0.2.1
+    image: ghcr.io/openfaas/ofc-gitlab-event:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -31,7 +31,7 @@ functions:
   gitlab-push:
     lang: go
     handler: ./gitlab-push
-    image: functions/gitlab-push:0.2.4
+    image: ghcr.io/openfaas/ofc-gitlab-push:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -47,7 +47,7 @@ functions:
   gitlab-status:
     lang: go
     handler: ./gitlab-status
-    image: functions/gitlab-status:0.1.3
+    image: ghcr.io/openfaas/ofc-gitlab-status:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -65,7 +65,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.17.0
+    image: ghcr.io/openfaas/ofc-git-tar:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system

--- a/templates/of-builder-dep.yml
+++ b/templates/of-builder-dep.yml
@@ -32,7 +32,7 @@ spec:
   {{ end }}
       containers:
       - name: of-builder
-        image: openfaas/of-builder:0.8.0
+        image: ghcr.io/openfaas/ofc-of-builder:0.14.4
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -67,7 +67,7 @@ spec:
   {{ end }}
       - name: of-buildkit
         args: ["--addr", "tcp://0.0.0.0:1234"]
-        image: moby/buildkit:v0.6.2
+        image: moby/buildkit:v0.7.2
         imagePullPolicy: Always
         ports:
         - containerPort: 1234

--- a/templates/stack.yml
+++ b/templates/stack.yml
@@ -7,7 +7,7 @@ functions:
   system-github-event:
     lang: go
     handler: ./github-event
-    image: functions/github-event:0.9.2
+    image: ghcr.io/${REPO:-openfaas}/ofc-github-event:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -29,7 +29,7 @@ functions:
   github-push:
     lang: go
     handler: ./github-push
-    image: functions/github-push:0.7.5
+    image: ghcr.io/${REPO:-openfaas}/ofc-github-push:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -51,7 +51,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: functions/of-git-tar:0.19.0
+    image: ghcr.io/${REPO:-openfaas}/ofc-git-tar:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -77,7 +77,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: functions/of-buildshiprun:0.14.0
+    image: ghcr.io/${REPO:-openfaas}/ofc-buildshiprun:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -101,7 +101,7 @@ functions:
   garbage-collect:
     lang: go
     handler: ./garbage-collect
-    image: functions/garbage-collect:0.4.7
+    image: ghcr.io/${REPO:-openfaas}/ofc-garbage-collect:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -122,7 +122,7 @@ functions:
   github-status:
     lang: go
     handler: ./github-status
-    image: functions/github-status:0.5.0
+    image: ghcr.io/${REPO:-openfaas}/ofc-github-status:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -144,7 +144,7 @@ functions:
   import-secrets:
     lang: go
     handler: ./import-secrets
-    image: functions/import-secrets:0.6.2
+    image: ghcr.io/${REPO:-openfaas}/ofc-import-secrets:0.14.4
     annotations:
       com.openfaas.serviceaccount: sealedsecrets-importer-rw
     labels:
@@ -164,7 +164,7 @@ functions:
   pipeline-log:
     lang: go
     handler: ./pipeline-log
-    image: functions/pipeline-log:0.3.5
+    image: ghcr.io/${REPO:-openfaas}/ofc-pipeline-log:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -182,8 +182,8 @@ functions:
 
   list-functions:
     lang: go
-    handler: ./list-functions
-    image: functions/list-functions:0.6.0
+    handler: ./list-ghcr.io/${REPO:-openfaas}
+    image: ghcr.io/${REPO:-openfaas}/ofc-list-functions:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -193,14 +193,14 @@ functions:
       read_debug: true
     environment_file:
       - gateway_config.yml
-    secrets:
+    secrets/auth.:
       - basic-auth-user
       - basic-auth-password
 
   audit-event:
     lang: go
     handler: ./audit-event
-    image: functions/audit-event:0.1.2
+    image: ghcr.io/${REPO:-openfaas}/ofc-audit-event:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -209,20 +209,25 @@ functions:
       - slack.yml
 
   echo:
-    skip_build: true
-    image: functions/alpine:latest
+    lang: go
+    handler: ./echo
+    image: ghcr.io/${REPO:-openfaas}/ofc-echo:0.14.4
     labels:
       openfaas-cloud: "1"
       com.openfaas.scale.zero: false
-    fprocess: cat
     environment:
       write_debug: true
       read_debug: true
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 32Mi
+      cpu: 50m
 
   metrics:
     lang: go
     handler: ./metrics
-    image: functions/system-metrics:0.2.0
+    image: ghcr.io/${REPO:-openfaas}/ofc-system-metrics:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -235,7 +240,7 @@ functions:
   function-logs:
     lang: go
     handler: ./function-logs
-    image: functions/function-logs:0.2.0
+    image: ghcr.io/${REPO:-openfaas}/ofc-function-logs:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description
This moved over to using the GHCR images at the most recent version,
0.14.4

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by deploying to a new cluster, all images pulled and started
cluster then live

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

