### PR TITLE
Change the get.sh owner value to openfaas

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -7,7 +7,7 @@
 
 export VERIFY_CHECKSUM=0
 export ALIAS=""
-export OWNER=openfaas-incubator
+export OWNER=openfaas
 export REPO=ofc-bootstrap
 export SUCCESS_CMD="$REPO version"
 export BINLOCATION="/usr/local/bin"


### PR DESCRIPTION
**What**
- update the OWNER value in the `get.sh` because the repo has cahgned
  from openfaas-incubator to openfaas


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the script locally

```sh
➜  ofc-bootstrap git:(master) ✗ sudo bash get.sh 
x86_64
Downloading package https://github.com/openfaas/ofc-bootstrap/releases/download/0.9.5/ofc-bootstrap as /tmp/ofc-bootstrap
Download complete.
Running with sufficient permissions to attempt to move ofc-bootstrap to /usr/local/bin
New version of ofc-bootstrap installed to /usr/local/bin
  ___  _____ ____ 
 / _ \|  ___/ ___|
| | | | |_ | |    
| |_| |  _|| |___ 
 \___/|_|   \____|
ofc-bootstrap
Bootstrap your own OpenFaaS Cloud within 100 seconds
Commit: 88f790dd37ea37149c55a47c6b60ab56307e77c3
Version: 0.9.5
```


## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

