### PR TITLE
Updating templates/aws.yml, using new/refactored register-image version

### DIFF
--- a/templates/aws.yml
+++ b/templates/aws.yml
@@ -8,7 +8,7 @@ functions:
   register-image:
     lang: go
     handler: ./register-image
-    image: ghcr.io/${REPO:-openfaas}/ofc-register-image:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-aws-register-image:0.14.4
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Signed-off-by: Santi Gutierrez <ssgutierrez42@gmail.com>

## Description

Link to the `register-image` image under `templates/aws.yml` does not resolve. 
Updating to https://github.com/orgs/openfaas/packages/container/package/ofc-aws-register-image

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran `faas-cli deploy -f aws.yml` on my cluster. 
`register-image` listed as "Ready"

## Checklist:

I have:

- [x] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

