### PR TITLE
Fix list-functions deployment in stack.yml

### DIFF
--- a/templates/stack.yml
+++ b/templates/stack.yml
@@ -182,7 +182,7 @@ functions:
 
   list-functions:
     lang: go
-    handler: ./list-ghcr.io/${REPO:-openfaas}
+    handler: ./list-functions
     image: ghcr.io/${REPO:-openfaas}/ofc-list-functions:0.14.4
     labels:
       openfaas-cloud: "1"
@@ -193,7 +193,7 @@ functions:
       read_debug: true
     environment_file:
       - gateway_config.yml
-    secrets/auth.:
+    secrets:
       - basic-auth-user
       - basic-auth-password
 


### PR DESCRIPTION
## Description
Fixes: https://github.com/openfaas/ofc-bootstrap/issues/242
The move to GHCR had a rogue vim replace all (functions --> ghcr.io/)
and thus the list-functions function got some random replacments.

This has been tested on a new cluster and the broken credentials for
list-function have been restored and now it can call the gateway

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New cluster deployment from scratch on master, then change the fix and re-deploy and it works


## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

