### PR TITLE
Update to 0.14.6 of OFC

### DIFF
--- a/example.init.yaml
+++ b/example.init.yaml
@@ -332,5 +332,5 @@ enable_ingress_operator: false
 
 ## Version of OpenFaaS Cloud from https://github.com/openfaas/openfaas-cloud/releases/
 ### Usage: release tag, a SHA or branch name
-openfaas_cloud_version: 0.14.4
+openfaas_cloud_version: 0.14.6
 

--- a/scripts/deploy-cloud-components.sh
+++ b/scripts/deploy-cloud-components.sh
@@ -83,7 +83,7 @@ fi
 kubectl create secret generic sealedsecrets-public-key -n openfaas-fn --from-file=../pub-cert.pem \
  --dry-run=client -o yaml | kubectl apply -f -
 
-TAG=0.14.4 faas-cli deploy -f ./dashboard/stack.yml
+TAG=0.14.6 faas-cli deploy -f ./dashboard/stack.yml
 
 sleep 2
 

--- a/scripts/generate-sha.sh
+++ b/scripts/generate-sha.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo -n $(head -c 16 /dev/urandom | shasum | cut -d " " -f 1)

--- a/templates/aws.yml
+++ b/templates/aws.yml
@@ -8,7 +8,7 @@ functions:
   register-image:
     lang: go
     handler: ./register-image
-    image: ghcr.io/${REPO:-openfaas}/ofc-aws-register-image:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-aws-register-image:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system

--- a/templates/edge-auth-dep.yml
+++ b/templates/edge-auth-dep.yml
@@ -32,7 +32,7 @@ spec:
             secretName: of-customers
       containers:
       - name: edge-auth
-        image: ghcr.io/openfaas/ofc-edge-auth:0.14.4
+        image: ghcr.io/openfaas/ofc-edge-auth:0.14.6
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/templates/gitlab.yml
+++ b/templates/gitlab.yml
@@ -6,7 +6,7 @@ functions:
   system-gitlab-event:
     lang: go
     handler: ./gitlab-event
-    image: ghcr.io/openfaas/ofc-gitlab-event:0.14.4
+    image: ghcr.io/openfaas/ofc-gitlab-event:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -31,7 +31,7 @@ functions:
   gitlab-push:
     lang: go
     handler: ./gitlab-push
-    image: ghcr.io/openfaas/ofc-gitlab-push:0.14.4
+    image: ghcr.io/openfaas/ofc-gitlab-push:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -47,7 +47,7 @@ functions:
   gitlab-status:
     lang: go
     handler: ./gitlab-status
-    image: ghcr.io/openfaas/ofc-gitlab-status:0.14.4
+    image: ghcr.io/openfaas/ofc-gitlab-status:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -65,7 +65,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: ghcr.io/openfaas/ofc-git-tar:0.14.4
+    image: ghcr.io/openfaas/ofc-git-tar:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system

--- a/templates/of-builder-dep.yml
+++ b/templates/of-builder-dep.yml
@@ -32,7 +32,7 @@ spec:
   {{ end }}
       containers:
       - name: of-builder
-        image: ghcr.io/openfaas/ofc-of-builder:0.14.4
+        image: ghcr.io/openfaas/ofc-of-builder:0.14.6
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/templates/stack.yml
+++ b/templates/stack.yml
@@ -7,7 +7,7 @@ functions:
   system-github-event:
     lang: go
     handler: ./github-event
-    image: ghcr.io/${REPO:-openfaas}/ofc-github-event:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-github-event:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -29,7 +29,7 @@ functions:
   github-push:
     lang: go
     handler: ./github-push
-    image: ghcr.io/${REPO:-openfaas}/ofc-github-push:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-github-push:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -51,7 +51,7 @@ functions:
   git-tar:
     lang: dockerfile
     handler: ./git-tar
-    image: ghcr.io/${REPO:-openfaas}/ofc-git-tar:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-git-tar:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -77,7 +77,7 @@ functions:
   buildshiprun:
     lang: go
     handler: ./buildshiprun
-    image: ghcr.io/${REPO:-openfaas}/ofc-buildshiprun:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-buildshiprun:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -101,7 +101,7 @@ functions:
   garbage-collect:
     lang: go
     handler: ./garbage-collect
-    image: ghcr.io/${REPO:-openfaas}/ofc-garbage-collect:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-garbage-collect:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -122,7 +122,7 @@ functions:
   github-status:
     lang: go
     handler: ./github-status
-    image: ghcr.io/${REPO:-openfaas}/ofc-github-status:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-github-status:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -143,7 +143,7 @@ functions:
   import-secrets:
     lang: go
     handler: ./import-secrets
-    image: ghcr.io/${REPO:-openfaas}/ofc-import-secrets:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-import-secrets:0.14.6
     annotations:
       com.openfaas.serviceaccount: sealedsecrets-importer-rw
     labels:
@@ -163,7 +163,7 @@ functions:
   pipeline-log:
     lang: go
     handler: ./pipeline-log
-    image: ghcr.io/${REPO:-openfaas}/ofc-pipeline-log:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-pipeline-log:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -182,7 +182,7 @@ functions:
   list-functions:
     lang: go
     handler: ./list-functions
-    image: ghcr.io/${REPO:-openfaas}/ofc-list-functions:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-list-functions:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -199,7 +199,7 @@ functions:
   audit-event:
     lang: go
     handler: ./audit-event
-    image: ghcr.io/${REPO:-openfaas}/ofc-audit-event:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-audit-event:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -210,7 +210,7 @@ functions:
   echo:
     lang: go
     handler: ./echo
-    image: ghcr.io/${REPO:-openfaas}/ofc-echo:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-echo:0.14.6
     labels:
       openfaas-cloud: "1"
       com.openfaas.scale.zero: false
@@ -226,7 +226,7 @@ functions:
   metrics:
     lang: go
     handler: ./metrics
-    image: ghcr.io/${REPO:-openfaas}/ofc-system-metrics:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-system-metrics:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system
@@ -239,7 +239,7 @@ functions:
   function-logs:
     lang: go
     handler: ./function-logs
-    image: ghcr.io/${REPO:-openfaas}/ofc-function-logs:0.14.4
+    image: ghcr.io/${REPO:-openfaas}/ofc-function-logs:0.14.6
     labels:
       openfaas-cloud: "1"
       role: openfaas-system


### PR DESCRIPTION
Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

## Description
Upgrade to OFC 0.14.6, which has links for Github App/Gitlab isntance and the Public SealedSecrets Key on the dashboard :tada: 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
deployed to new ARM cluster

## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [ ] updated the documentation and/or roadmap in README.md
- [ ] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

