### PR TITLE
Add field to enable openfaas operator

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -27,7 +27,7 @@ k3sup install --ip $IP --user $USER --k3s-extra-args "--no-deploy traefik"
 Example with [k3d](https://github.com/rancher/k3d):
 
 ```sh
-k3d create --server-arg "--no-deploy=traefik"
+k3d cluster create --k3s-server-arg "--no-deploy=traefik"
 ```
 
 Newer k3d versions will require an alternative:

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -323,7 +323,7 @@ func process(plan types.Plan, prefs InstallPreferences) error {
 		log.Println(functionAuthErr.Error())
 	}
 
-	if err := installOpenfaas(plan.ScaleToZero, plan.IngressOperator); err != nil {
+	if err := installOpenfaas(plan.ScaleToZero, plan.IngressOperator, plan.OpenFaaSOperator); err != nil {
 		return errors.Wrap(err, "unable to install openfaas")
 	}
 
@@ -531,7 +531,7 @@ func installSealedSecrets() error {
 	return nil
 }
 
-func installOpenfaas(scaleToZero, ingressOperator bool) error {
+func installOpenfaas(scaleToZero, ingressOperator, openfaasOperator bool) error {
 	log.Println("Installing openfaas")
 
 	args := []string{"install", "openfaas",
@@ -551,6 +551,7 @@ func installOpenfaas(scaleToZero, ingressOperator bool) error {
 		"--set faasnetes.httpProbe=true",
 		"--set faasnetes.imagePullPolicy=IfNotPresent",
 		"--set ingressOperator.create=" + strconv.FormatBool(ingressOperator),
+		"--set operator.create=" + strconv.FormatBool(openfaasOperator),
 		"--wait",
 	}
 

--- a/example.init.yaml
+++ b/example.init.yaml
@@ -328,9 +328,12 @@ build_branch: master
 
 ## This setting, if true, will install the openfaas ingress-operator using the openfaas-fn namespace
 ## for finding functions, creating Ingress records in the openfaas namespace
-enable_ingress_operator: false
+ingress_operator: false
 
 ## Version of OpenFaaS Cloud from https://github.com/openfaas/openfaas-cloud/releases/
 ### Usage: release tag, a SHA or branch name
 openfaas_cloud_version: 0.14.6
 
+## This setting, if true, will deploy OpenFaaS and use the OpenFaaS operator CRD controller, 
+## default uses faas-netes as the Kubernetes controller
+openfaas_operator: false

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -69,7 +69,8 @@ type Plan struct {
 	EnableECR            bool                     `yaml:"enable_ecr,omitempty"`
 	ECRConfig            ECRConfig                `yaml:"ecr_config,omitempty"`
 	CustomersSecret      bool                     `yaml:"customers_secret,omitempty"`
-	IngressOperator      bool                     `yaml:"enable_ingress_operator,omitempty"`
+	IngressOperator      bool                     `yaml:"ingress_operator,omitempty"`
+	OpenFaaSOperator     bool                     `yaml:"openfaas_operator,omitempty"`
 }
 
 // Deployment is the deployment section of YAML concerning


### PR DESCRIPTION
This commit adds field `enable_openfaas_operator` to deploy OpenFaaS with operator

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this on my local k3s cluster with this repo with crd deployed https://github.com/viveksyngh/openfaas-functions/runs/1562603783

```
k get crd
NAME                        CREATED AT
addons.k3s.cattle.io        2020-12-16T08:28:16Z
helmcharts.helm.cattle.io   2020-12-16T08:28:16Z
functions.openfaas.com      2020-12-16T08:29:28Z
profiles.openfaas.com       2020-12-16T08:29:28Z
sealedsecrets.bitnami.com   2020-12-16T08:30:10Z
tunnels.inlets.inlets.dev   2020-12-16T08:31:48Z
```

## Checklist:

I have:

- [ ] checked my changes follow the style of the existing code / OpenFaaS repos
- [x] updated the documentation and/or roadmap in README.md
- [x] read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests

